### PR TITLE
Filter active MotionEvents where end time is None

### DIFF
--- a/protect_archiver/downloader/get_motion_event_list.py
+++ b/protect_archiver/downloader/get_motion_event_list.py
@@ -33,17 +33,18 @@ def get_motion_event_list(
 
     motion_event_list = []
     for motion_event in motion_events:
-        motion_event_list.append(
-            MotionEvent(
-                id=motion_event["id"],
-                start=datetime.fromtimestamp(motion_event["start"] / 1000),
-                end=datetime.fromtimestamp(motion_event["end"] / 1000),
-                camera_id=motion_event["camera"],
-                score=motion_event["score"],
-                thumbnail_id=motion_event["thumbnail"],
-                heatmap_id=motion_event["heatmap"],
+        if not (motion_event["end"] is None):
+            motion_event_list.append(
+                MotionEvent(
+                    id=motion_event["id"],
+                    start=datetime.fromtimestamp(motion_event["start"] / 1000),
+                    end=datetime.fromtimestamp(motion_event["end"] / 1000),
+                    camera_id=motion_event["camera"],
+                    score=motion_event["score"],
+                    thumbnail_id=motion_event["thumbnail"],
+                    heatmap_id=motion_event["heatmap"],
+                )
             )
-        )
 
     # noinspection PyTypeHints
     event_count_by_camera = Counter(e.camera_id for e in motion_event_list)


### PR DESCRIPTION
As described in #65, if a motion event is still ongoing at the time of requesting a clip, it results in an error due to the fact that there is no `end` time available yet.

Adding an additional filter to the MotionEvent list generator to exclude ongoing events without an `end` time should fix the problem (https://github.com/danielfernau/unifi-protect-video-downloader/compare/master...65-fix-active-motion-events?quick_pull=1#diff-9df10edd19226f0ba49275eaf18605692cb7c6c72fdbd227539553d4c4d5eba8R37)

---

See PR #115