### PR TITLE
Add support for local time and GMT in file names

### DIFF
--- a/protect_archiver/cli/download.py
+++ b/protect_archiver/cli/download.py
@@ -151,6 +151,13 @@ from protect_archiver.utils import print_download_stats
         "This flag cannot be used in combination with the normal video download mode."
     ),
 )
+@click.option(
+    "--use-utc-filenames",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Use UTC timestamp in file names instead of local time",
+)
 def download(
     dest: str,
     address: str,
@@ -169,6 +176,7 @@ def download(
     start: datetime,
     end: datetime,
     create_snapshot: bool,
+    use_utc_filenames: bool,
 ) -> None:
     # check the provided command line arguments
     # TODO(danielfernau): remove exit codes 1 (path invalid) and 6 (start/end/snapshot) from docs: no longer valid
@@ -194,6 +202,7 @@ def download(
         skip_existing_files=skip_existing_files,
         touch_files=touch_files,
         download_timeout=download_timeout,
+        use_utc_filenames=use_utc_filenames,
     )
 
     try:

--- a/protect_archiver/cli/events.py
+++ b/protect_archiver/cli/events.py
@@ -147,6 +147,13 @@ from protect_archiver.utils import print_download_stats
     show_default=True,
     help="Also download motion heatmaps for event recordings",
 )
+@click.option(
+    "--use-utc-filenames",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Use UTC timestamp in file names instead of local time",
+)
 def events(
     dest: str,
     address: str,
@@ -165,6 +172,7 @@ def events(
     start: datetime,
     end: datetime,
     download_motion_heatmaps: bool,
+    use_utc_filenames: bool,
 ) -> None:
     client = ProtectClient(
         address=address,
@@ -180,6 +188,7 @@ def events(
         skip_existing_files=skip_existing_files,
         touch_files=touch_files,
         download_timeout=download_timeout,
+        use_utc_filenames=use_utc_filenames,
     )
 
     try:

--- a/protect_archiver/cli/sync.py
+++ b/protect_archiver/cli/sync.py
@@ -79,6 +79,13 @@ from protect_archiver.utils import print_download_stats
         "Use '--cameras=all' to download footage of all available cameras."
     ),
 )
+@click.option(
+    "--use-utc-filenames",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Use UTC timestamp in file names instead of local time",
+)
 def sync(
     dest: str,
     address: str,
@@ -91,6 +98,7 @@ def sync(
     ignore_state: bool,
     ignore_failed_downloads: bool,
     cameras: str,
+    use_utc_filenames: bool,
 ) -> None:
     # normalize path to destination directory and check if it exists
     dest = path.abspath(dest)
@@ -108,6 +116,7 @@ def sync(
         destination_path=dest,
         ignore_failed_downloads=ignore_failed_downloads,
         use_subfolders=True,
+        use_utc_filenames=use_utc_filenames,
     )
 
     # get camera list

--- a/protect_archiver/client/__init__.py
+++ b/protect_archiver/client/__init__.py
@@ -29,6 +29,7 @@ class ProtectClient:
         touch_files: bool = Config.TOUCH_FILES,
         # aka read_timeout - time to wait until a socket read response happens
         download_timeout: float = Config.DOWNLOAD_TIMEOUT,
+        use_utc_filenames: bool = Config.USE_UTC_FILENAMES,
     ) -> None:
         self.protocol = protocol
         self.address = address
@@ -44,6 +45,7 @@ class ProtectClient:
         self.use_subfolders = use_subfolders
         self.skip_existing_files = skip_existing_files
         self.touch_files = touch_files
+        self.use_utc_filenames = use_utc_filenames
 
         self.destination_path = path.abspath(destination_path)
 

--- a/protect_archiver/config.py
+++ b/protect_archiver/config.py
@@ -22,3 +22,4 @@ class Config:
         60.0  # aka read_timeout - time to wait until a socket read response happens
     )
     MAX_RETRIES: int = 3
+    USE_UTC_FILENAMES: bool = False

--- a/protect_archiver/downloader/download_footage.py
+++ b/protect_archiver/downloader/download_footage.py
@@ -7,7 +7,8 @@ from typing import Any
 
 from protect_archiver.dataclasses import Camera
 from protect_archiver.downloader.download_file import download_file
-from protect_archiver.utils import calculate_intervals, build_download_dir
+from protect_archiver.utils import build_download_dir
+from protect_archiver.utils import calculate_intervals
 from protect_archiver.utils import make_camera_name_fs_safe
 
 

--- a/protect_archiver/downloader/download_footage.py
+++ b/protect_archiver/downloader/download_footage.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from datetime import datetime
+from datetime import timezone
 from os import path
 from typing import Any
 
@@ -32,11 +33,15 @@ def download_footage(client: Any, start: datetime, end: datetime, camera: Camera
         js_timestamp_range_start = int(interval_start.timestamp()) * 1000
         js_timestamp_range_end = int(interval_end.timestamp()) * 1000
 
-        download_dir, interval_start_tz = build_download_dir(
+        # support selection between local time zone and UTC for file names
+        interval_start_tz = (
+            interval_start.astimezone(timezone.utc) if client.use_utc_filenames else interval_start
+        )
+
+        download_dir = build_download_dir(
             use_subfolders=client.use_subfolders,
             destination_path=client.destination_path,
-            interval_start=interval_start,
-            use_utc_filenames=client.use_utc_filenames,
+            interval_start_tz=interval_start_tz,
             camera_name_fs_safe=camera_name_fs_safe,
         )
 

--- a/protect_archiver/downloader/download_footage.py
+++ b/protect_archiver/downloader/download_footage.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 
 from datetime import datetime
@@ -8,7 +7,7 @@ from typing import Any
 
 from protect_archiver.dataclasses import Camera
 from protect_archiver.downloader.download_file import download_file
-from protect_archiver.utils import calculate_intervals
+from protect_archiver.utils import calculate_intervals, build_download_dir
 from protect_archiver.utils import make_camera_name_fs_safe
 
 
@@ -32,27 +31,16 @@ def download_footage(client: Any, start: datetime, end: datetime, camera: Camera
         js_timestamp_range_start = int(interval_start.timestamp()) * 1000
         js_timestamp_range_end = int(interval_end.timestamp()) * 1000
 
-        # file path for download
-        if bool(client.use_subfolders):
-            folder_year = interval_start.strftime("%Y")
-            folder_month = interval_start.strftime("%m")
-            folder_day = interval_start.strftime("%d")
-
-            dir_by_date_and_name = (
-                f"{folder_year}/{folder_month}/{folder_day}/{camera_name_fs_safe}"
-            )
-            target_with_date_and_name = f"{client.destination_path}/{dir_by_date_and_name}"
-
-            download_dir = target_with_date_and_name
-            if not os.path.isdir(target_with_date_and_name):
-                os.makedirs(target_with_date_and_name, exist_ok=True)
-                logging.info(f"Created path {target_with_date_and_name}")
-                download_dir = target_with_date_and_name
-        else:
-            download_dir = client.destination_path
+        download_dir, interval_start_tz = build_download_dir(
+            use_subfolders=client.use_subfolders,
+            destination_path=client.destination_path,
+            interval_start=interval_start,
+            use_utc_filenames=client.use_utc_filenames,
+            camera_name_fs_safe=camera_name_fs_safe,
+        )
 
         # file name for download
-        filename_timestamp = interval_start.strftime("%Y-%m-%d - %H.%M.%S%z")
+        filename_timestamp = interval_start_tz.strftime("%Y-%m-%d - %H.%M.%S%z")
         filename = f"{download_dir}/{camera_name_fs_safe} - {filename_timestamp}.mp4"
 
         logging.info(

--- a/protect_archiver/downloader/download_motion_event.py
+++ b/protect_archiver/downloader/download_motion_event.py
@@ -1,5 +1,6 @@
 import logging
 
+from datetime import timezone
 from typing import Any
 
 from protect_archiver.dataclasses import Camera
@@ -19,11 +20,17 @@ def download_motion_event(
     js_timestamp_start = int(motion_event.start.timestamp()) * 1000
     js_timestamp_end = int(motion_event.end.timestamp()) * 1000
 
-    download_dir, interval_start_tz = build_download_dir(
+    # support selection between local time zone and UTC for file names
+    interval_start_tz = (
+        motion_event.start.astimezone(timezone.utc)
+        if client.use_utc_filenames
+        else motion_event.start
+    )
+
+    download_dir = build_download_dir(
         use_subfolders=client.use_subfolders,
         destination_path=client.destination_path,
-        interval_start=motion_event.start,
-        use_utc_filenames=client.use_utc_filenames,
+        interval_start_tz=interval_start_tz,
         camera_name_fs_safe=camera_name_fs_safe,
     )
 

--- a/protect_archiver/downloader/download_motion_event.py
+++ b/protect_archiver/downloader/download_motion_event.py
@@ -5,7 +5,8 @@ from typing import Any
 from protect_archiver.dataclasses import Camera
 from protect_archiver.dataclasses import MotionEvent
 from protect_archiver.downloader.download_file import download_file
-from protect_archiver.utils import make_camera_name_fs_safe, build_download_dir
+from protect_archiver.utils import build_download_dir
+from protect_archiver.utils import make_camera_name_fs_safe
 
 
 def download_motion_event(

--- a/protect_archiver/downloader/download_motion_event.py
+++ b/protect_archiver/downloader/download_motion_event.py
@@ -1,12 +1,11 @@
 import logging
-import os
 
 from typing import Any
 
 from protect_archiver.dataclasses import Camera
 from protect_archiver.dataclasses import MotionEvent
 from protect_archiver.downloader.download_file import download_file
-from protect_archiver.utils import make_camera_name_fs_safe
+from protect_archiver.utils import make_camera_name_fs_safe, build_download_dir
 
 
 def download_motion_event(
@@ -19,25 +18,16 @@ def download_motion_event(
     js_timestamp_start = int(motion_event.start.timestamp()) * 1000
     js_timestamp_end = int(motion_event.end.timestamp()) * 1000
 
-    # file path for download
-    if bool(client.use_subfolders):
-        folder_year = motion_event.start.strftime("%Y")
-        folder_month = motion_event.start.strftime("%m")
-        folder_day = motion_event.start.strftime("%d")
-
-        dir_by_date_and_name = f"{folder_year}/{folder_month}/{folder_day}/{camera_name_fs_safe}"
-        target_with_date_and_name = f"{client.destination_path}/{dir_by_date_and_name}"
-
-        download_dir = target_with_date_and_name
-        if not os.path.isdir(target_with_date_and_name):
-            os.makedirs(target_with_date_and_name, exist_ok=True)
-            logging.info(f"Created path {target_with_date_and_name}")
-            download_dir = target_with_date_and_name
-    else:
-        download_dir = client.destination_path
+    download_dir, interval_start_tz = build_download_dir(
+        use_subfolders=client.use_subfolders,
+        destination_path=client.destination_path,
+        interval_start=motion_event.start,
+        use_utc_filenames=client.use_utc_filenames,
+        camera_name_fs_safe=camera_name_fs_safe,
+    )
 
     # file name for download
-    filename_timestamp = motion_event.start.strftime("%Y-%m-%d - %H.%M.%S%z")
+    filename_timestamp = interval_start_tz.strftime("%Y-%m-%d - %H.%M.%S%z")
     filename = f"{download_dir}/{camera_name_fs_safe} - {filename_timestamp}.mp4"
 
     logging.info(

--- a/protect_archiver/downloader/download_snapshot.py
+++ b/protect_archiver/downloader/download_snapshot.py
@@ -13,25 +13,16 @@ def download_snapshot(client: Any, start: datetime, camera: Camera) -> None:
     # make camera name safe for use in file name
     camera_name_fs_safe = make_camera_name_fs_safe(camera)
 
-    # file path for download
-    if bool(client.use_subfolders):
-        folder_year = start.strftime("%Y")
-        folder_month = start.strftime("%m")
-        folder_day = start.strftime("%d")
-
-        dir_by_date_and_name = f"{folder_year}/{folder_month}/{folder_day}/{camera_name_fs_safe}"
-        target_with_date_and_name = f"{client.destination_path}/{dir_by_date_and_name}"
-
-        download_dir = target_with_date_and_name
-        if not os.path.isdir(target_with_date_and_name):
-            os.makedirs(target_with_date_and_name, exist_ok=True)
-            logging.info(f"Created path {target_with_date_and_name}")
-            download_dir = target_with_date_and_name
-    else:
-        download_dir = client.destination_path
+    download_dir, interval_start_tz = build_download_dir(
+        use_subfolders=client.use_subfolders,
+        destination_path=client.destination_path,
+        interval_start=start,
+        use_utc_filenames=client.use_utc_filenames,
+        camera_name_fs_safe=camera_name_fs_safe,
+    )
 
     # file name for download
-    filename_timestamp = start.strftime("%Y-%m-%d - %H.%M.%S%z")
+    filename_timestamp = interval_start_tz.strftime("%Y-%m-%d - %H.%M.%S%z")
     filename = f"{download_dir}/{camera_name_fs_safe} - {filename_timestamp}.jpg"
 
     logging.info(

--- a/protect_archiver/downloader/download_snapshot.py
+++ b/protect_archiver/downloader/download_snapshot.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from datetime import datetime
+from datetime import timezone
 from typing import Any
 
 from protect_archiver.dataclasses import Camera
@@ -14,11 +15,13 @@ def download_snapshot(client: Any, start: datetime, camera: Camera) -> None:
     # make camera name safe for use in file name
     camera_name_fs_safe = make_camera_name_fs_safe(camera)
 
-    download_dir, interval_start_tz = build_download_dir(
+    # support selection between local time zone and UTC for file names
+    interval_start_tz = start.astimezone(timezone.utc) if client.use_utc_filenames else start
+
+    download_dir = build_download_dir(
         use_subfolders=client.use_subfolders,
         destination_path=client.destination_path,
-        interval_start=start,
-        use_utc_filenames=client.use_utc_filenames,
+        interval_start_tz=interval_start_tz,
         camera_name_fs_safe=camera_name_fs_safe,
     )
 

--- a/protect_archiver/downloader/download_snapshot.py
+++ b/protect_archiver/downloader/download_snapshot.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from protect_archiver.dataclasses import Camera
 from protect_archiver.downloader.download_file import download_file
+from protect_archiver.utils import build_download_dir
 from protect_archiver.utils import make_camera_name_fs_safe
 
 

--- a/protect_archiver/utils.py
+++ b/protect_archiver/utils.py
@@ -1,8 +1,12 @@
 import logging
 import os
 
-from datetime import datetime, timedelta, timezone
-from typing import Any, Iterable, Tuple
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+from typing import Iterable
+from typing import Tuple
 
 from protect_archiver.dataclasses import Camera
 

--- a/protect_archiver/utils.py
+++ b/protect_archiver/utils.py
@@ -3,7 +3,6 @@ import os
 
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
 from typing import Any
 from typing import Iterable
 from typing import Tuple
@@ -106,15 +105,9 @@ def print_download_stats(client: Any) -> None:
 def build_download_dir(
     use_subfolders: bool,
     destination_path: str,
-    interval_start: datetime,
-    use_utc_filenames: bool,
+    interval_start_tz: datetime,
     camera_name_fs_safe: str,
-) -> tuple[str, datetime]:
-    # support selection between local time zone and UTC for file names
-    interval_start_tz = (
-        interval_start.astimezone(timezone.utc) if use_utc_filenames else interval_start
-    )
-
+) -> str:
     # build file path for download
     if bool(use_subfolders):
         folder_year = interval_start_tz.strftime("%Y")
@@ -132,4 +125,4 @@ def build_download_dir(
     else:
         download_dir = destination_path
 
-    return download_dir, interval_start_tz
+    return download_dir


### PR DESCRIPTION
Adds `--use-utc-filenames` to `download`, `events` and `sync` commands (default: False; uses local time if omitted)

Resolves #30 