### PR TITLE
Fix legacy authentication

### DIFF
--- a/protect_archiver/downloader/download_file.py
+++ b/protect_archiver/downloader/download_file.py
@@ -31,12 +31,22 @@ def download_file(client: Any, query: str, filename: str) -> None:
         # make the GET request to retrieve the video file or snapshot
         try:
             start = time.monotonic()
-            response = requests.get(
-                uri,
-                cookies={"TOKEN": client.session.get_api_token()},
-                verify=client.verify_ssl,
-                timeout=client.download_timeout,
-                stream=True,
+            response = (
+                requests.get(
+                    uri,
+                    cookies={"TOKEN": client.session.get_api_token()},
+                    verify=client.verify_ssl,
+                    timeout=client.download_timeout,
+                    stream=True,
+                )
+                if client.session.__class__.__name__ == "UniFiOSClient"
+                else requests.get(
+                    uri,
+                    headers={"Authorization": f"Bearer {client.session.get_api_token()}"},
+                    verify=client.verify_ssl,
+                    timeout=client.download_timeout,
+                    stream=True,
+                )
             )
 
             if response.status_code == 401:
@@ -44,12 +54,24 @@ def download_file(client: Any, query: str, filename: str) -> None:
                 # as we dont want to retry on consecutive auth failures
                 # TODO: refactor this
                 start = time.monotonic()
-                response = requests.get(
-                    uri,
-                    cookies={"TOKEN": client.session.get_api_token(force=True)},
-                    verify=client.verify_ssl,
-                    timeout=client.download_timeout,
-                    stream=True,
+                response = (
+                    requests.get(
+                        uri,
+                        cookies={"TOKEN": client.session.get_api_token(force=True)},
+                        verify=client.verify_ssl,
+                        timeout=client.download_timeout,
+                        stream=True,
+                    )
+                    if client.session.__class__.__name__ == "UniFiOSClient"
+                    else requests.get(
+                        uri,
+                        headers={
+                            "Authorization": f"Bearer {client.session.get_api_token(force=True)}"
+                        },
+                        verify=client.verify_ssl,
+                        timeout=client.download_timeout,
+                        stream=True,
+                    )
                 )
 
             # write file to disk if response.status_code is 200,

--- a/protect_archiver/downloader/get_camera_list.py
+++ b/protect_archiver/downloader/get_camera_list.py
@@ -13,11 +13,20 @@ from protect_archiver.dataclasses import Camera
 def get_camera_list(session: Any, connected: bool = True) -> List[Camera]:
     cameras_uri = f"{session.authority}{session.base_path}/cameras"
 
-    response = requests.get(
-        cameras_uri,
-        cookies={"TOKEN": session.get_api_token()},
-        verify=session.verify_ssl,
+    response = (
+        requests.get(
+            cameras_uri,
+            cookies={"TOKEN": session.get_api_token()},
+            verify=session.verify_ssl,
+        )
+        if session.__class__.__name__ == "UniFiOSClient"
+        else requests.get(
+            cameras_uri,
+            headers={"Authorization": f"Bearer {session.get_api_token()}"},
+            verify=session.verify_ssl,
+        )
     )
+
     if response.status_code != 200:
         print(f"Error while loading camera list: {response.status_code}")
         return []

--- a/protect_archiver/downloader/get_motion_event_list.py
+++ b/protect_archiver/downloader/get_motion_event_list.py
@@ -19,11 +19,21 @@ def get_motion_event_list(
         f"{session.authority}{session.base_path}/events?type=motion"
         f"&start={int(start.timestamp()) * 1000}&end={int(end.timestamp()) * 1000}"
     )
-    response = requests.get(
-        motion_events_uri,
-        cookies={"TOKEN": session.get_api_token()},
-        verify=session.verify_ssl,
+
+    response = (
+        requests.get(
+            motion_events_uri,
+            cookies={"TOKEN": session.get_api_token()},
+            verify=session.verify_ssl,
+        )
+        if session.__class__.__name__ == "UniFiOSClient"
+        else requests.get(
+            motion_events_uri,
+            headers={"Authorization": f"Bearer {session.get_api_token()}"},
+            verify=session.verify_ssl,
+        )
     )
+
     if response.status_code != 200:
         print(f"Error while loading motion events list: {response.status_code}")
         return []


### PR DESCRIPTION
Use TOKEN cookie authentication for UniFiOSClient and Authorization header authentication for LegacyClient

Resolves #155 
Fixes #168 