### PR TITLE
Fix unhandled exception in download_file.py after response error 104 (Connection reset by peer)

### DIFF
--- a/protect_archiver/downloader/download_file.py
+++ b/protect_archiver/downloader/download_file.py
@@ -118,7 +118,7 @@ def download_file(client: Any, query: str, filename: str) -> None:
                         return
 
                     with open(filename, "wb") as fp:
-                        for chunk in response.iter_content(4096):
+                        for chunk in response.iter_content(None):
                             cur_bytes += len(chunk)
                             fp.write(chunk)
                             # TODO


### PR DESCRIPTION
Changed buffer size in "response.iter_content()" from hard-coded "4096" to "None" which according to models.py documentation uses a dynamic buffer in stream mode rather than fixed buffer (which appeared to have caused an overrun in this situation).

This error started to appear after recent UniFi firmware update versions (switching from production to early access firmware did not fix it, appears to be new behaviour). I also checked the computer where the downloads run to ensure it has all updates including Docker Desktop and network drivers, tested different network settings for stability, different adapters (LAN or WiFi) even directly attached to the UniFi DM SE where the UniFi NVR was locally connected (different network cables too).

The error situation appears to be new behaviour. The only special case could be that the cameras (video stream being downloaded) had disconnects or rebooted for updates multiple times on the day being downloaded.