### PR TITLE
Adding flag to skip rounding to the hour

### DIFF
--- a/protect_archiver/cli/download.py
+++ b/protect_archiver/cli/download.py
@@ -141,6 +141,14 @@ from protect_archiver.utils import print_download_stats
     ),
 )
 @click.option(
+    "--skip-round-to-hour",
+    "skip_round_to_hour",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Skips rounding the clips to hour markers."
+)
+@click.option(
     "--snapshot",
     "create_snapshot",
     is_flag=True,
@@ -175,6 +183,7 @@ def download(
     ignore_failed_downloads: bool,
     start: datetime,
     end: datetime,
+    skip_round_to_hour: bool,
     create_snapshot: bool,
     use_utc_filenames: bool,
 ) -> None:
@@ -224,7 +233,7 @@ def download(
                     f" {camera.name}"
                 )
 
-                Downloader.download_footage(client, start, end, camera)
+                Downloader.download_footage(client, start, end, camera, skip_round_to_hour)
         else:
             click.echo(
                 f"Downloading snapshot files for {start.ctime()}"

--- a/protect_archiver/cli/download.py
+++ b/protect_archiver/cli/download.py
@@ -146,7 +146,7 @@ from protect_archiver.utils import print_download_stats
     is_flag=True,
     default=False,
     show_default=True,
-    help="Skips rounding the clips to hour markers."
+    help="Skips rounding the clips to hour markers.",
 )
 @click.option(
     "--snapshot",

--- a/protect_archiver/downloader/__init__.py
+++ b/protect_archiver/downloader/__init__.py
@@ -43,8 +43,8 @@ class Downloader:
         return download_file(client, video_export_query, filename)
 
     @staticmethod
-    def download_footage(client: Any, start: datetime, end: datetime, camera: Any) -> Any:
-        return download_footage(client, start, end, camera)
+    def download_footage(client: Any, start: datetime, end: datetime, camera: Any, skip_round_to_hour: bool) -> Any:
+        return download_footage(client, start, end, camera, skip_round_to_hour)
 
     @staticmethod
     def download_snapshot(client: Any, start: datetime, camera: Any) -> Any:

--- a/protect_archiver/downloader/__init__.py
+++ b/protect_archiver/downloader/__init__.py
@@ -43,7 +43,9 @@ class Downloader:
         return download_file(client, video_export_query, filename)
 
     @staticmethod
-    def download_footage(client: Any, start: datetime, end: datetime, camera: Any, skip_round_to_hour: bool) -> Any:
+    def download_footage(
+        client: Any, start: datetime, end: datetime, camera: Any, skip_round_to_hour: bool
+    ) -> Any:
         return download_footage(client, start, end, camera, skip_round_to_hour)
 
     @staticmethod

--- a/protect_archiver/downloader/download_footage.py
+++ b/protect_archiver/downloader/download_footage.py
@@ -13,7 +13,9 @@ from protect_archiver.utils import calculate_intervals
 from protect_archiver.utils import make_camera_name_fs_safe
 
 
-def download_footage(client: Any, start: datetime, end: datetime, camera: Camera, skip_round_to_hour: bool) -> None:
+def download_footage(
+    client: Any, start: datetime, end: datetime, camera: Camera, skip_round_to_hour: bool
+) -> None:
     # make camera name safe for use in file name
     camera_name_fs_safe = make_camera_name_fs_safe(camera)
 

--- a/protect_archiver/downloader/download_footage.py
+++ b/protect_archiver/downloader/download_footage.py
@@ -24,7 +24,7 @@ def download_footage(
     if skip_round_to_hour:
         intervals = [(start, end)]
     else:
-        intervals = calculate_intervals(start, end)
+        intervals = calculate_intervals(start, end) # type: ignore  # noqa
 
     # split requested time frame into chunks of 1 hour or less and download them one by one
     for interval_start, interval_end in intervals:

--- a/protect_archiver/downloader/download_footage.py
+++ b/protect_archiver/downloader/download_footage.py
@@ -13,14 +13,19 @@ from protect_archiver.utils import calculate_intervals
 from protect_archiver.utils import make_camera_name_fs_safe
 
 
-def download_footage(client: Any, start: datetime, end: datetime, camera: Camera) -> None:
+def download_footage(client: Any, start: datetime, end: datetime, camera: Camera, skip_round_to_hour: bool) -> None:
     # make camera name safe for use in file name
     camera_name_fs_safe = make_camera_name_fs_safe(camera)
 
     logging.info(f"Downloading footage for camera '{camera.name}' ({camera.id})")
 
+    if skip_round_to_hour:
+        intervals = [(start, end)]
+    else:
+        intervals = calculate_intervals(start, end)
+
     # split requested time frame into chunks of 1 hour or less and download them one by one
-    for interval_start, interval_end in calculate_intervals(start, end):
+    for interval_start, interval_end in intervals:
         # wait n seconds before starting next download (if parameter is set)
         if client.download_wait != 0 and client.files_downloaded == 0:
             logging.debug(

--- a/protect_archiver/sync.py
+++ b/protect_archiver/sync.py
@@ -52,7 +52,7 @@ class ProtectSync:
                 )
                 end = datetime.now().replace(minute=0, second=0, microsecond=0)
                 for interval_start, interval_end in calculate_intervals(start, end):
-                    Downloader.download_footage(self.client, interval_start, interval_end, camera)
+                    Downloader.download_footage(self.client, interval_start, interval_end, camera, False)
                     state["cameras"][camera.id] = {
                         "last": interval_end,
                         "name": camera.name,

--- a/protect_archiver/test_client.py
+++ b/protect_archiver/test_client.py
@@ -75,7 +75,7 @@ def test_download_footage(
     start = datetime(2020, 1, 8, 23, 0, 0, tzinfo=timezone.utc)
     end = datetime(2020, 1, 8, 23, 59, 0, tzinfo=timezone.utc)
 
-    Downloader.download_footage(client, start, end, sample_camera)
+    Downloader.download_footage(client, start, end, sample_camera, False)
 
     file_name = os.path.join(
         test_output_dest,


### PR DESCRIPTION
Adds `--skip-round-to-hour`

This leaves the default functionality in place but adds a new flag to skip rounding the clips to the hour(ish)

fixes: #34 #57 

I know that the UI can download a time range but for me if that clip is more than ~1m it crashes, it also frequently crashes when scanning over footage, so this is easier/more reliable.