### PR TITLE
Add support for environment variables

### DIFF
--- a/protect_archiver/cli/download.py
+++ b/protect_archiver/cli/download.py
@@ -18,6 +18,8 @@ from protect_archiver.utils import print_download_stats
     show_default=True,
     required=True,
     help="IP address or hostname of the UniFi Protect Server",
+    envvar="PROTECT_ADDRESS",
+    show_envvar=True,
 )
 @click.option(
     "--port",
@@ -25,6 +27,8 @@ from protect_archiver.utils import print_download_stats
     show_default=True,
     required=False,
     help="The port of the UniFi Protect Server",
+    envvar="PROTECT_PORT",
+    show_envvar=True,
 )
 @click.option(
     "--not-unifi-os",
@@ -32,12 +36,16 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Use this for systems without UniFi OS",
+    envvar="PROTECT_NOT_UNIFI_OS",
+    show_envvar=True,
 )
 @click.option(
     "--username",
     required=True,
     help="Username of user with local access.",
     prompt="Username of local Protect user",
+    envvar="PROTECT_USERNAME",
+    show_envvar=True,
 )
 @click.option(
     "--password",
@@ -45,6 +53,8 @@ from protect_archiver.utils import print_download_stats
     help="Password of user with local access",
     prompt="Password for local Protect user",
     hide_input=True,
+    envvar="PROTECT_PASSWORD",
+    show_envvar=True,
 )
 @click.option(
     "--verify-ssl",
@@ -52,6 +62,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Verify Protect SSL certificate",
+    envvar="PROTECT_VERIFY_SSL",
+    show_envvar=True,
 )
 @click.option(
     "--cameras",
@@ -61,6 +73,8 @@ from protect_archiver.utils import print_download_stats
         "Comma-separated list of one or more camera IDs ('--cameras=\"id_1,id_2,id_3,...\"'). "
         "Use '--cameras=all' to download footage of all available cameras."
     ),
+    envvar="PROTECT_CAMERAS",
+    show_envvar=True,
 )
 @click.option(
     "--wait-between-downloads",
@@ -68,6 +82,8 @@ from protect_archiver.utils import print_download_stats
     default=0,
     show_default=True,
     help="Time to wait between file downloads, in seconds",
+    envvar="PROTECT_WAIT_BETWEEN_DOWNLOADS",
+    show_envvar=True,
 )
 @click.option(
     "--ignore-failed-downloads",
@@ -75,6 +91,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Ignore failed downloads and continue with next download",
+    envvar="PROTECT_IGNORE_FAILED_DOWNLOADS",
+    show_envvar=True,
 )
 @click.option(
     "--skip-existing-files",
@@ -82,6 +100,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Skip downloading files which already exist on disk",
+    envvar="PROTECT_SKIP_EXISTING",
+    show_envvar=True,
 )
 @click.option(
     "--touch-files",
@@ -92,12 +112,16 @@ from protect_archiver.utils import print_download_stats
         "Create local file without content for current download - "
         "useful in combination with '--skip-existing-files' to skip problematic segments"
     ),
+    envvar="PROTECT_TOUCH_FILES",
+    show_envvar=True,
 )
 @click.option(
     "--use-subfolders/--no-use-subfolders",
     default=True,
     show_default=True,
     help="Save footage to folder structure with format 'YYYY/MM/DD/camera_name/'",
+    envvar="PROTECT_USE_SUBFOLDERS",
+    show_envvar=True,
 )
 @click.option(
     "--download-request-timeout",
@@ -105,6 +129,8 @@ from protect_archiver.utils import print_download_stats
     default=60.0,
     show_default=True,
     help="Time to wait before aborting download request, in seconds",
+    envvar="PROTECT_DOWNLOAD_TIMEOUT",
+    show_envvar=True,
 )
 @click.option(
     "--start",
@@ -122,6 +148,8 @@ from protect_archiver.utils import print_download_stats
         # TODO(danielfernau): uncomment the next line as soon as the feature is implemented
         # "If omitted, the time of the first available recording for each camera will be used."
     ),
+    envvar="PROTECT_START_TIME",
+    show_envvar=True,
 )
 @click.option(
     "--end",
@@ -139,6 +167,8 @@ from protect_archiver.utils import print_download_stats
         # TODO(danielfernau): uncomment the next line as soon as the feature is implemented
         # "If omitted, the time of the last available recording for each camera will be used."
     ),
+    envvar="PROTECT_END_TIME",
+    show_envvar=True,
 )
 @click.option(
     "--disable-alignment",
@@ -150,6 +180,8 @@ from protect_archiver.utils import print_download_stats
         "Disables alignment of the 1-hour segments to absolute hours. "
         "If set, results in 8:45, 9:45, 10:45 instead of 8:45, 9:00, 10:00, 10:45."
     ),
+    envvar="PROTECT_DISABLE_ALIGNMENT",
+    show_envvar=True,
 )
 @click.option(
     "--disable-splitting",
@@ -162,6 +194,8 @@ from protect_archiver.utils import print_download_stats
         "USE WITH CAUTION: requesting segments longer than 1 hour via the "
         "API can cause the Protect console to crash and restart unexpectedly."
     ),
+    envvar="PROTECT_DISABLE_SPLITTING",
+    show_envvar=True,
 )
 @click.option(
     "--snapshot",
@@ -173,6 +207,8 @@ from protect_archiver.utils import print_download_stats
         "Capture and download a snapshot from the specified camera(s). "
         "This flag cannot be used in combination with the normal video download mode."
     ),
+    envvar="PROTECT_CREATE_SNAPSHOT",
+    show_envvar=True,
 )
 @click.option(
     "--use-utc-filenames",
@@ -180,6 +216,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Use UTC timestamp in file names instead of local time",
+    envvar="PROTECT_USE_UTC",
+    show_envvar=True,
 )
 def download(
     dest: str,

--- a/protect_archiver/cli/events.py
+++ b/protect_archiver/cli/events.py
@@ -18,6 +18,8 @@ from protect_archiver.utils import print_download_stats
     show_default=True,
     required=True,
     help="IP address or hostname of the UniFi Protect Server",
+    envvar="PROTECT_ADDRESS",
+    show_envvar=True,
 )
 @click.option(
     "--port",
@@ -25,6 +27,8 @@ from protect_archiver.utils import print_download_stats
     show_default=True,
     required=False,
     help="The port of the UniFi Protect Server",
+    envvar="PROTECT_PORT",
+    show_envvar=True,
 )
 @click.option(
     "--not-unifi-os",
@@ -32,12 +36,16 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Use this for systems without UniFi OS",
+    envvar="PROTECT_NOT_UNIFI_OS",
+    show_envvar=True,
 )
 @click.option(
     "--username",
     required=True,
     help="Username of user with local access",
     prompt="Username of local Protect user",
+    envvar="PROTECT_USERNAME",
+    show_envvar=True,
 )
 @click.option(
     "--password",
@@ -45,6 +53,8 @@ from protect_archiver.utils import print_download_stats
     help="Password of user with local access",
     prompt="Password for local Protect user",
     hide_input=True,
+    envvar="PROTECT_PASSWORD",
+    show_envvar=True,
 )
 @click.option(
     "--verify-ssl",
@@ -52,6 +62,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Verify Protect SSL certificate",
+    envvar="PROTECT_VERIFY_SSL",
+    show_envvar=True,
 )
 @click.option(
     "--cameras",
@@ -61,6 +73,8 @@ from protect_archiver.utils import print_download_stats
         "Comma-separated list of one or more camera IDs ('--cameras=\"id_1,id_2,id_3,...\"'). "
         "Use '--cameras=all' to download footage of all available cameras."
     ),
+    envvar="PROTECT_CAMERAS",
+    show_envvar=True,
 )
 @click.option(
     "--wait-between-downloads",
@@ -68,6 +82,8 @@ from protect_archiver.utils import print_download_stats
     default=0,
     show_default=True,
     help="Time to wait between file downloads, in seconds",
+    envvar="PROTECT_WAIT_BETWEEN_DOWNLOADS",
+    show_envvar=True,
 )
 @click.option(
     "--ignore-failed-downloads",
@@ -75,6 +91,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Ignore failed downloads and continue with next download",
+    envvar="PROTECT_IGNORE_FAILED_DOWNLOADS",
+    show_envvar=True,
 )
 @click.option(
     "--skip-existing-files",
@@ -82,6 +100,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Skip downloading files which already exist on disk",
+    envvar="PROTECT_SKIP_EXISTING",
+    show_envvar=True,
 )
 @click.option(
     "--touch-files",
@@ -92,12 +112,16 @@ from protect_archiver.utils import print_download_stats
         "Create local file without content for current download - "
         "useful in combination with '--skip-existing-files' to skip problematic segments"
     ),
+    envvar="PROTECT_TOUCH_FILES",
+    show_envvar=True,
 )
 @click.option(
     "--use-subfolders/--no-use-subfolders",
     default=True,
     show_default=True,
     help="Save footage to folder structure with format 'YYYY/MM/DD/camera_name/'",
+    envvar="PROTECT_USE_SUBFOLDERS",
+    show_envvar=True,
 )
 @click.option(
     "--download-request-timeout",
@@ -105,6 +129,8 @@ from protect_archiver.utils import print_download_stats
     default=60.0,
     show_default=True,
     help="Time to wait before aborting download request, in seconds",
+    envvar="PROTECT_DOWNLOAD_TIMEOUT",
+    show_envvar=True,
 )
 @click.option(
     "--start",
@@ -122,6 +148,8 @@ from protect_archiver.utils import print_download_stats
         # TODO(danielfernau): uncomment the next line as soon as the feature is implemented
         # "If omitted, the time of the first available recording for each camera will be used."
     ),
+    envvar="PROTECT_START_TIME",
+    show_envvar=True,
 )
 @click.option(
     "--end",
@@ -139,6 +167,8 @@ from protect_archiver.utils import print_download_stats
         # TODO(danielfernau): uncomment the next line as soon as the feature is implemented
         # "If omitted, the time of the last available recording for each camera will be used."
     ),
+    envvar="PROTECT_END_TIME",
+    show_envvar=True,
 )
 @click.option(
     "--download-motion-heatmaps",
@@ -146,6 +176,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Also download motion heatmaps for event recordings",
+    envvar="PROTECT_DOWNLOAD_MOTION_HEATMAPS",
+    show_envvar=True,
 )
 @click.option(
     "--use-utc-filenames",
@@ -153,6 +185,8 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Use UTC timestamp in file names instead of local time",
+    envvar="PROTECT_USE_UTC",
+    show_envvar=True,
 )
 def events(
     dest: str,

--- a/protect_archiver/cli/sync.py
+++ b/protect_archiver/cli/sync.py
@@ -84,7 +84,6 @@ from protect_archiver.utils import print_download_stats
     envvar="PROTECT_IGNORE_FAILED_DOWNLOADS",
     show_envvar=True,
 )
-
 @click.option(
     "--use-utc-filenames",
     is_flag=True,

--- a/protect_archiver/cli/sync.py
+++ b/protect_archiver/cli/sync.py
@@ -13,17 +13,21 @@ from protect_archiver.utils import print_download_stats
 @click.argument("dest", type=click.Path(exists=True, writable=True, resolve_path=True))
 @click.option(
     "--address",
-    default="unifi",
+    default=Config.ADDRESS,
     show_default=True,
     required=True,
-    help="CloudKey IP address or hostname",
+    help="IP address or hostname of the UniFi Protect Server",
+    envvar="PROTECT_ADDRESS",
+    show_envvar=True,
 )
 @click.option(
     "--port",
     default=Config.PORT,
     show_default=True,
     required=False,
-    help="CloudKey port",
+    help="The port of the UniFi Protect Server",
+    envvar="PROTECT_PORT",
+    show_envvar=True,
 )
 @click.option(
     "--not-unifi-os",
@@ -31,12 +35,16 @@ from protect_archiver.utils import print_download_stats
     default=False,
     show_default=True,
     help="Use this for systems without UniFi OS",
+    envvar="PROTECT_NOT_UNIFI_OS",
+    show_envvar=True,
 )
 @click.option(
     "--username",
     required=True,
     help="Username of user with local access",
     prompt="Username of local Protect user",
+    envvar="PROTECT_USERNAME",
+    show_envvar=True,
 )
 @click.option(
     "--password",
@@ -44,31 +52,17 @@ from protect_archiver.utils import print_download_stats
     help="Password of user with local access",
     prompt="Password for local Protect user",
     hide_input=True,
-)
-@click.option(
-    "--statefile",
-    default="sync.state",
-    show_default=True,
-)
-@click.option(
-    "--ignore-state",
-    is_flag=True,
-    default=False,
-    show_default=True,
+    envvar="PROTECT_PASSWORD",
+    show_envvar=True,
 )
 @click.option(
     "--verify-ssl",
     is_flag=True,
     default=False,
     show_default=True,
-    help="Verify CloudKey SSL certificate",
-)
-@click.option(
-    "--ignore-failed-downloads",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="Ignore failed downloads and continue with next download",
+    help="Verify Protect SSL certificate",
+    envvar="PROTECT_VERIFY_SSL",
+    show_envvar=True,
 )
 @click.option(
     "--cameras",
@@ -78,13 +72,42 @@ from protect_archiver.utils import print_download_stats
         "Comma-separated list of one or more camera IDs ('--cameras=\"id_1,id_2,id_3,...\"'). "
         "Use '--cameras=all' to download footage of all available cameras."
     ),
+    envvar="PROTECT_CAMERAS",
+    show_envvar=True,
 )
+@click.option(
+    "--ignore-failed-downloads",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Ignore failed downloads and continue with next download",
+    envvar="PROTECT_IGNORE_FAILED_DOWNLOADS",
+    show_envvar=True,
+)
+
 @click.option(
     "--use-utc-filenames",
     is_flag=True,
     default=False,
     show_default=True,
     help="Use UTC timestamp in file names instead of local time",
+    envvar="PROTECT_USE_UTC",
+    show_envvar=True,
+)
+@click.option(
+    "--statefile",
+    default="sync.state",
+    show_default=True,
+    envvar="PROTECT_SYNC_STATEFILE",
+    show_envvar=True,
+)
+@click.option(
+    "--ignore-state",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    envvar="PROTECT_SYNC_IGNORE_STATE",
+    show_envvar=True,
 )
 def sync(
     dest: str,


### PR DESCRIPTION
Adds support for environment variables to be used instead of command line options/arguments

### For the `download` command:
- `PROTECT_ADDRESS` for `--address`
- `PROTECT_PORT` for `--port`
- `PROTECT_NOT_UNIFI_OS` for `--not-unifi-os`
- `PROTECT_USERNAME` for `--username`
- `PROTECT_PASSWORD` for `--password`
- `PROTECT_VERIFY_SSL` for `--verify-ssl`
- `PROTECT_CAMERAS` for `--cameras`
- `PROTECT_WAIT_BETWEEN_DOWNLOADS` for `--wait-between-downloads`
- `PROTECT_IGNORE_FAILED_DOWNLOADS` for `--ignore-failed-downloads`
- `PROTECT_SKIP_EXISTING` for `--skip-existing-files`
- `PROTECT_TOUCH_FILES` for `--touch-files`
- `PROTECT_USE_SUBFOLDERS` for `--use-subfolders` (use `true` or `1`)/`--no-use-subfolders` (use `false`, `0`, or omit env var)
- `PROTECT_DOWNLOAD_TIMEOUT` for `--download-request-timeout`
- `PROTECT_START_TIME` for `--start`
- `PROTECT_END_TIME` for `--end`
- `PROTECT_DISABLE_ALIGNMENT` for `--disable-alignment`
- `PROTECT_DISABLE_SPLITTING` for `--disable-splitting`
- `PROTECT_CREATE_SNAPSHOT` for `--snapshot`
- `PROTECT_USE_UTC` for `--use-utc-filenames`

### For the `events` command
- `PROTECT_ADDRESS` for `--address` 
- `PROTECT_PORT` for `--port` 
- `PROTECT_NOT_UNIFI_OS` for `--not-unifi-os` 
- `PROTECT_USERNAME` for `--username` 
- `PROTECT_PASSWORD` for `--password` 
- `PROTECT_VERIFY_SSL` for `--verify-ssl` 
- `PROTECT_CAMERAS` for `--cameras` 
- `PROTECT_WAIT_BETWEEN_DOWNLOADS` for `--wait-between-downloads` 
- `PROTECT_IGNORE_FAILED_DOWNLOADS` for `--ignore-failed-downloads` 
- `PROTECT_SKIP_EXISTING` for `--skip-existing-files` 
- `PROTECT_TOUCH_FILES` for `--touch-files` 
- `PROTECT_USE_SUBFOLDERS` for `--use-subfolders` (use `true` or `1`)/`--no-use-subfolders` (use `false`, `0`, or omit env var)
- `PROTECT_DOWNLOAD_TIMEOUT` for `--download-request-timeout` 
- `PROTECT_START_TIME` for `--start` 
- `PROTECT_END_TIME` for `--end` 
- `PROTECT_DOWNLOAD_MOTION_HEATMAPS` for `--download-motion-heatmaps` 
- `PROTECT_USE_UTC` for `--use-utc-filenames` 

### For the `sync` command
- `PROTECT_ADDRESS` for `--address` 
- `PROTECT_PORT` for `--port` 
- `PROTECT_NOT_UNIFI_OS` for `--not-unifi-os` 
- `PROTECT_USERNAME` for `--username` 
- `PROTECT_PASSWORD` for `--password` 
- `PROTECT_VERIFY_SSL` for `--verify-ssl` 
- `PROTECT_CAMERAS` for `--cameras` 
- `PROTECT_IGNORE_FAILED_DOWNLOADS` for `--ignore-failed-downloads` 
- `PROTECT_USE_UTC` for `--use-utc-filenames` 
- `PROTECT_SYNC_STATEFILE` for `--statefile`
- `PROTECT_SYNC_IGNORE_STATE` for `--ignore-state`

---
Implements and closes #385 