### PR TITLE
Add timelapse support

### DIFF
--- a/protect_archiver/cli/download.py
+++ b/protect_archiver/cli/download.py
@@ -219,6 +219,26 @@ from protect_archiver.utils import print_download_stats
     envvar="PROTECT_USE_UTC",
     show_envvar=True,
 )
+@click.option(
+    "--timelapse",
+    is_flag=True,
+    default=Config.TIMELAPSE,
+    show_default=True,
+    required=False,
+    help="Export a timelapse video. Note: must use in conjunction with FPS",
+    envvar="PROTECT_TIMELAPSE",
+    show_envvar=True,
+)
+@click.option(
+    "--fps",
+    default=Config.FPS,
+    show_default=True,
+    required=False,
+    help="Frames Per Second for the exported video (options are 4, 8, 20, or 40). Note: must be used in conjunction with TIMELAPSE option",
+    envvar="PROTECT_FPS",
+    show_envvar=True,
+)
+
 def download(
     dest: str,
     address: str,
@@ -240,6 +260,9 @@ def download(
     disable_splitting: bool,
     create_snapshot: bool,
     use_utc_filenames: bool,
+    timelapse: bool,
+    fps: str,
+
 ) -> None:
     # check the provided command line arguments
     # TODO(danielfernau): remove exit codes 1 (path invalid) and 6 (start/end/snapshot) from docs: no longer valid
@@ -266,6 +289,8 @@ def download(
         touch_files=touch_files,
         download_timeout=download_timeout,
         use_utc_filenames=use_utc_filenames,
+        timelapse=timelapse,
+        fps=fps,
     )
 
     try:
@@ -288,7 +313,7 @@ def download(
                 )
 
                 Downloader.download_footage(
-                    client, start, end, camera, disable_alignment, disable_splitting
+                    client, start, end, camera, disable_alignment, disable_splitting, timelapse, fps
                 )
         else:
             click.echo(

--- a/protect_archiver/cli/download.py
+++ b/protect_archiver/cli/download.py
@@ -234,7 +234,8 @@ from protect_archiver.utils import print_download_stats
     default=Config.FPS,
     show_default=True,
     required=False,
-    help="Frames Per Second for the exported video (options are 4, 8, 20, or 40). Note: must be used in conjunction with TIMELAPSE option",
+    help="Frames Per Second for the exported video (options are 4, 8, 20, or 40). " \
+         "Note: must be used in conjunction with TIMELAPSE option",
     envvar="PROTECT_FPS",
     show_envvar=True,
 )

--- a/protect_archiver/client/__init__.py
+++ b/protect_archiver/client/__init__.py
@@ -30,6 +30,8 @@ class ProtectClient:
         # aka read_timeout - time to wait until a socket read response happens
         download_timeout: float = Config.DOWNLOAD_TIMEOUT,
         use_utc_filenames: bool = Config.USE_UTC_FILENAMES,
+        timelapse: bool = Config.TIMELAPSE,
+        fps: str = Config.FPS,
     ) -> None:
         self.protocol = protocol
         self.address = address
@@ -46,6 +48,8 @@ class ProtectClient:
         self.skip_existing_files = skip_existing_files
         self.touch_files = touch_files
         self.use_utc_filenames = use_utc_filenames
+        self.timelapse = timelapse
+        self.fps = fps
 
         self.destination_path = path.abspath(destination_path)
 

--- a/protect_archiver/config.py
+++ b/protect_archiver/config.py
@@ -25,3 +25,5 @@ class Config:
     )
     MAX_RETRIES: int = 3
     USE_UTC_FILENAMES: bool = False
+    TIMELAPSE: bool = False
+    FPS: str = None

--- a/protect_archiver/downloader/__init__.py
+++ b/protect_archiver/downloader/__init__.py
@@ -50,8 +50,10 @@ class Downloader:
         camera: Any,
         disable_alignment: bool = Config.DISABLE_ALIGNMENT,
         disable_splitting: bool = Config.DISABLE_SPLITTING,
+        timelapse: bool = Config.TIMELAPSE,
+        fps: str = Config.FPS
     ) -> Any:
-        return download_footage(client, start, end, camera, disable_alignment, disable_splitting)
+        return download_footage(client, start, end, camera, disable_alignment, disable_splitting, timelapse, fps)
 
     @staticmethod
     def download_snapshot(client: Any, start: datetime, camera: Any) -> Any:

--- a/protect_archiver/downloader/download_footage.py
+++ b/protect_archiver/downloader/download_footage.py
@@ -20,6 +20,8 @@ def download_footage(
     camera: Camera,
     disable_alignment: bool = False,
     disable_splitting: bool = False,
+    timelapse: bool = False,
+    fps: str = None,
 ) -> None:
     # make camera name safe for use in file name
     camera_name_fs_safe = make_camera_name_fs_safe(camera)
@@ -72,7 +74,9 @@ def download_footage(
             open(filename, "a").close()
 
         # build video export query
-        video_export_query = f"/video/export?camera={camera.id}&start={js_timestamp_range_start}&end={js_timestamp_range_end}"
+        video_export_query = f"/video/export?camera={camera.id}&start={js_timestamp_range_start}&end={js_timestamp_range_end}"    
+        if timelapse:
+            video_export_query = video_export_query + f"&type=timelapse&fps={fps}"
 
         # download the file
         download_file(client, video_export_query, filename)


### PR DESCRIPTION
Adds two new parameters to allow for downloading a timelapse version of the video:

- TIMELAPSE : Boolean; specify whether or not to download the timelapse version of a video; default FALSE
- FPS : Str; the frames per second the video should be encoded in (options are 4, 8, 20, and 40)